### PR TITLE
update: old method

### DIFF
--- a/src/events/track/trackEnds.js
+++ b/src/events/track/trackEnds.js
@@ -22,7 +22,9 @@ function trackEnds(Event, payload, node, config, Nodes, Players) {
       
       utils.makeNodeRequest(Nodes, node, `/v4/sessions/${Nodes[node].sessionId}/players/${payload.guildId}`, {
         body: {
-          encodedTrack: player.queue[0]
+          track: {
+            encoded: player.queue[0]
+          }
         },
         method: 'PATCH'
       })


### PR DESCRIPTION
## Changes

Updating the old `PATCH` method at `trackEnd` event.

## Why 

old `PATCH` method with `encodedTrack` is deprecated with the new one.

## Checkmarks

- [x] The modified functions have been tested.
- [x] Used the same indentation as the rest of the project.