### PR TITLE
change: prevent current playing track from being shuffled

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,7 +389,8 @@ class Player {
       return false
 
     Players[this.guildId].queue.forEach((_, i) => {
-      if(i === 0) return;
+      if (i === 0) return;
+      
       const j = Math.floor(Math.random() * (i + 1))
       const temp = Players[this.guildId].queue[i]
       Players[this.guildId].queue[i] = Players[this.guildId].queue[j]

--- a/index.js
+++ b/index.js
@@ -379,7 +379,7 @@ class Player {
   /**
    * Shuffles the queue of tracks.
    * 
-   * @return The shuffled queue of tracks, or false if there are less than 3 tracks in the queue.
+   * @return The shuffled queue of tracks, or false if there are less than 3 tracks in the queue. The current playing track will not be shuffled.
    * @throws Error If the queue is disabled.
    */
   shuffle() {
@@ -389,6 +389,7 @@ class Player {
       return false
 
     Players[this.guildId].queue.forEach((_, i) => {
+      if(i === 0) return;
       const j = Math.floor(Math.random() * (i + 1))
       const temp = Players[this.guildId].queue[i]
       Players[this.guildId].queue[i] = Players[this.guildId].queue[j]


### PR DESCRIPTION
## Changes

Shuffling will no longer switch the position of the current playing track.

## Why 

Prevents unwanted issues where the playback of the track before the shuffle is still playing afterwards and other track information is displayed because they switched order.

## Checkmarks

- [X] The modified functions have been tested.
- [X] Used the same indentation as the rest of the project.

## Additional information

