### PR TITLE
Provide the track information of the ended track in trackEnd event

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,7 +389,8 @@ class Player {
       return false
 
     Players[this.guildId].queue.forEach((_, i) => {
-      if(i === 0) return;
+      if (i === 0) return;
+      
       const j = Math.floor(Math.random() * (i + 1))
       const temp = Players[this.guildId].queue[i]
       Players[this.guildId].queue[i] = Players[this.guildId].queue[j]

--- a/index.js
+++ b/index.js
@@ -379,7 +379,7 @@ class Player {
   /**
    * Shuffles the queue of tracks.
    * 
-   * @return The shuffled queue of tracks, or false if there are less than 3 tracks in the queue.
+   * @return The shuffled queue of tracks, or false if there are less than 3 tracks in the queue. The current playing track will not be shuffled.
    * @throws Error If the queue is disabled.
    */
   shuffle() {
@@ -389,6 +389,7 @@ class Player {
       return false
 
     Players[this.guildId].queue.forEach((_, i) => {
+      if(i === 0) return;
       const j = Math.floor(Math.random() * (i + 1))
       const temp = Players[this.guildId].queue[i]
       Players[this.guildId].queue[i] = Players[this.guildId].queue[j]

--- a/src/events/track/trackEnds.js
+++ b/src/events/track/trackEnds.js
@@ -13,6 +13,8 @@ function trackEnds(Event, payload, node, config, Nodes, Players) {
     return Players
   }
 
+  const ended_track = player.queue[0]
+
   if (name !== 'trackException' && config.queue && ['finished', 'loadFailed'].includes(payload.reason)) {
     switch (player.loop) {
       case 'track': {
@@ -56,7 +58,7 @@ function trackEnds(Event, payload, node, config, Nodes, Players) {
     thresholdMs: payload.thresholdMs
   })
 
-  return Players
+  return [Players, ended_track]
 }
 
 export default trackEnds


### PR DESCRIPTION
## Changes

In this PR, the trackEnd event will also emit the ended track in a second argument rather than just the player

## Why 

Can be useful in cases where the user wants to check information related to the ended track.

## Checkmarks

- [X] The modified functions have been tested.
- [X] Used the same indentation as the rest of the project.

## Additional information

If you have any additional information, write it here
